### PR TITLE
Add referencedRoutePaths parameter to AfdDomain to resolve S360 issue.

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/preview/2023-07-01-preview/afdx.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/preview/2023-07-01-preview/afdx.json
@@ -4740,6 +4740,17 @@
           "readOnly": true,
           "type": "object",
           "$ref": "#/definitions/DomainValidationProperties"
+        },
+        "referencedRoutePaths": {
+          "description": "The JSON object list that contains the overall picture of how routes are used for the shared custom domain across different profiles.",
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AFDDomainReferencedRoutePath"
+          },
+          "x-ms-identifiers": [
+            "/routeId/id"
+          ]
         }
       }
     },
@@ -4828,6 +4839,24 @@
           "description": "Resource reference to the secret. ie. subs/rg/profile/secret",
           "type": "object",
           "$ref": "./cdn.json#/definitions/ResourceReference"
+        }
+      }
+    },
+    "AFDDomainReferencedRoutePath": {
+      "description": "route configuration of the shared custom domain.",
+      "type": "object",
+      "properties": {
+        "routeId": {
+          "description": "Resource reference to the route.",
+          "type": "object",
+          "$ref": "./cdn.json#/definitions/ResourceReference"
+        },
+        "paths": {
+          "description": "List of paths of the route.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

Add new parameter referencedRoutePaths for custom domains of 1p profiles. The referenced route paths are mapped from CP reserved routes.

## Purpose of this PR

The purpose of this PR is to update existing version to fix swagger quality issues in S360.
