### PR TITLE
[CDN] Add AuthPolicy resource to 2026-08-01-preview

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/AuthPolicy.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/AuthPolicy.tsp
@@ -61,10 +61,8 @@ interface AuthPolicies {
     PatchModel = AuthPolicyUpdateParameters,
     Response =
       | ArmResponse<AuthPolicy>
-      | ArmAcceptedLroResponse<
-          LroHeaders = ArmCombinedLroHeaders<FinalResult = AuthPolicy> &
-            Azure.Core.Foundations.RetryAfterHeader
-        >
+      | ArmAcceptedLroResponse<LroHeaders = ArmCombinedLroHeaders<FinalResult = AuthPolicy> &
+          Azure.Core.Foundations.RetryAfterHeader>
   >;
 
   /**
@@ -74,9 +72,8 @@ interface AuthPolicies {
   delete is ArmResourceDeleteWithoutOkAsync<
     AuthPolicy,
     Response =
-      | ArmDeleteAcceptedLroResponse<
-          ArmCombinedLroHeaders & Azure.Core.Foundations.RetryAfterHeader
-        >
+      | ArmDeleteAcceptedLroResponse<ArmCombinedLroHeaders &
+          Azure.Core.Foundations.RetryAfterHeader>
       | ArmDeletedNoContentResponse
   >;
 
@@ -90,6 +87,15 @@ interface AuthPolicies {
 @@doc(AuthPolicy.name, "Name of the authorization policy under the profile.");
 @@minLength(AuthPolicy.name, 1);
 @@maxLength(AuthPolicy.name, 260);
-@@doc(AuthPolicy.properties, "Properties required to create an authorization policy.");
-@@doc(AuthPolicies.create::parameters.resource, "The authorization policy properties.");
-@@doc(AuthPolicies.update::parameters.properties, "Authorization policy update properties.");
+@@doc(
+  AuthPolicy.properties,
+  "Properties required to create an authorization policy."
+);
+@@doc(
+  AuthPolicies.create::parameters.resource,
+  "The authorization policy properties."
+);
+@@doc(
+  AuthPolicies.update::parameters.properties,
+  "Authorization policy update properties."
+);

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/AuthPolicy.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/AuthPolicy.tsp
@@ -1,0 +1,95 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./Profile.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Microsoft.Cdn;
+
+/**
+ * An authorization policy that maps authorization configurations to profile, domain, or route associations.
+ */
+@added(Versions.v2026_08_01_preview)
+@parentResource(Profile)
+model AuthPolicy is Azure.ResourceManager.ProxyResource<AuthPolicyProperties> {
+  ...ResourceNameParameter<
+    Resource = AuthPolicy,
+    KeyName = "authPolicyName",
+    SegmentName = "authPolicies",
+    NamePattern = "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+  >;
+}
+
+@added(Versions.v2026_08_01_preview)
+@armResourceOperations
+interface AuthPolicies {
+  /**
+   * Gets an existing authorization policy within a profile.
+   */
+  get is ArmResourceRead<AuthPolicy>;
+
+  /**
+   * Creates or updates an authorization policy within the specified profile.
+   */
+  @Azure.Core.useFinalStateVia("azure-async-operation")
+  create is ArmResourceCreateOrReplaceAsync<
+    AuthPolicy,
+    Response =
+      | ArmResourceUpdatedResponse<AuthPolicy>
+      | ArmResourceCreatedResponse<
+          AuthPolicy,
+          LroHeaders = ArmAsyncOperationHeader<FinalResult = AuthPolicy> &
+            Azure.Core.Foundations.RetryAfterHeader
+        >
+  >;
+
+  /**
+   * Updates an existing authorization policy within a profile.
+   */
+  @Azure.Core.useFinalStateVia("azure-async-operation")
+  @patch(#{ implicitOptionality: false })
+  update is ArmCustomPatchAsync<
+    AuthPolicy,
+    PatchModel = AuthPolicyUpdateParameters,
+    Response =
+      | ArmResponse<AuthPolicy>
+      | ArmAcceptedLroResponse<
+          LroHeaders = ArmCombinedLroHeaders<FinalResult = AuthPolicy> &
+            Azure.Core.Foundations.RetryAfterHeader
+        >
+  >;
+
+  /**
+   * Deletes an existing authorization policy within a profile.
+   */
+  @Azure.Core.useFinalStateVia("azure-async-operation")
+  delete is ArmResourceDeleteWithoutOkAsync<
+    AuthPolicy,
+    Response =
+      | ArmDeleteAcceptedLroResponse<
+          ArmCombinedLroHeaders & Azure.Core.Foundations.RetryAfterHeader
+        >
+      | ArmDeletedNoContentResponse
+  >;
+
+  /**
+   * Lists authorization policies associated with the profile.
+   */
+  @list
+  listByProfile is ArmResourceListByParent<AuthPolicy>;
+}
+
+@@doc(AuthPolicy.name, "Name of the authorization policy under the profile.");
+@@minLength(AuthPolicy.name, 1);
+@@maxLength(AuthPolicy.name, 260);
+@@doc(AuthPolicy.properties, "Properties required to create an authorization policy.");
+@@doc(AuthPolicies.create::parameters.resource, "The authorization policy properties.");
+@@doc(AuthPolicies.update::parameters.properties, "Authorization policy update properties.");

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Create.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Create.json
@@ -36,6 +36,42 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Block",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      }
+    },
     "201": {
       "body": {
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Create.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Create.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "resource": {
+      "properties": {
+        "action": "Block",
+        "associations": {
+          "domains": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+            }
+          ],
+          "isProfileLevel": false,
+          "routes": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+            }
+          ]
+        },
+        "authConfigs": [
+          {
+            "audiences": [
+              "11111111-1111-1111-1111-111111111111"
+            ],
+            "authLocation": "Header",
+            "authLocationSelector": "Authorization",
+            "identityProvider": "EntraID",
+            "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Block",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Creating"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Retry-After": 30
+      }
+    }
+  },
+  "operationId": "AuthPolicies_Create",
+  "title": "AuthPolicies_Create"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Delete.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Retry-After": 30
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AuthPolicies_Delete",
+  "title": "AuthPolicies_Delete"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Get.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Block",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      }
+    }
+  },
+  "operationId": "AuthPolicies_Get",
+  "title": "AuthPolicies_Get"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_ListByProfile.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_ListByProfile.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "profileName": "profile1",
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+            "name": "authPolicy1",
+            "properties": {
+              "action": "Block",
+              "associations": {
+                "domains": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+                  }
+                ],
+                "isProfileLevel": false,
+                "routes": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+                  }
+                ]
+              },
+              "authConfigs": [
+                {
+                  "audiences": [
+                    "11111111-1111-1111-1111-111111111111"
+                  ],
+                  "authLocation": "Header",
+                  "authLocationSelector": "Authorization",
+                  "identityProvider": "EntraID",
+                  "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+                }
+              ],
+              "deploymentStatus": "NotStarted",
+              "provisioningState": "Succeeded"
+            },
+            "type": "Microsoft.Cdn/profiles/authPolicies"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AuthPolicies_ListByProfile",
+  "title": "AuthPolicies_ListByProfile"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Update.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/examples/2026-08-01-preview/AuthPolicies_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "properties": {
+      "properties": {
+        "action": "Log"
+      }
+    },
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Log",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Retry-After": 30
+      }
+    }
+  },
+  "operationId": "AuthPolicies_Update",
+  "title": "AuthPolicies_Update"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/main.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/main.tsp
@@ -21,6 +21,7 @@ import "./Route.tsp";
 import "./RuleSet.tsp";
 import "./Rule.tsp";
 import "./SecurityPolicy.tsp";
+import "./AuthPolicy.tsp";
 import "./Secret.tsp";
 import "./KeyGroup.tsp";
 import "./DeploymentVersion.tsp";

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/models.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/models.tsp
@@ -3327,6 +3327,187 @@ model ActivatedResourceReference {
 }
 
 /**
+ * Properties of the authorization policy.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "The service contract composes writable authorization policy properties with Azure Front Door state properties."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "The existing Azure Front Door state model defines the service's provisioning state contract."
+@added(Versions.v2026_08_01_preview)
+model AuthPolicyProperties extends AFDStateProperties {
+  /**
+   * Authorization configurations for the policy.
+   */
+  @identifiers(#[])
+  @minItems(1)
+  authConfigs: AuthPolicyConfig[];
+
+  /**
+   * Resource associations for the authorization policy.
+   */
+  associations: AuthPolicyAssociation;
+
+  /**
+   * Action to apply when authorization fails.
+   */
+  action?: AuthPolicyAction = AuthPolicyAction.Block;
+}
+
+/**
+ * Parameters for updating an authorization policy.
+ */
+@added(Versions.v2026_08_01_preview)
+model AuthPolicyUpdateParameters {
+  /**
+   * Properties to update on the authorization policy.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "The existing Swagger contract flattens the properties payload for SDK compatibility."
+  @Azure.ClientGenerator.Core.Legacy.flattenProperty
+  properties?: AuthPolicyUpdatePropertiesParameters;
+}
+
+/**
+ * Writable properties of an authorization policy.
+ */
+@added(Versions.v2026_08_01_preview)
+model AuthPolicyUpdatePropertiesParameters {
+  /**
+   * Authorization configurations for the policy.
+   */
+  @identifiers(#[])
+  @minItems(1)
+  authConfigs?: AuthPolicyConfig[];
+
+  /**
+   * Resource associations for the authorization policy.
+   */
+  associations?: AuthPolicyAssociation;
+
+  /**
+   * Action to apply when authorization fails.
+   */
+  action?: AuthPolicyAction;
+}
+
+/**
+ * Resource associations for an authorization policy.
+ */
+@added(Versions.v2026_08_01_preview)
+model AuthPolicyAssociation {
+  /**
+   * Indicates whether the policy is associated at the profile level.
+   */
+  isProfileLevel?: boolean = false;
+
+  /**
+   * Domains associated with the authorization policy.
+   */
+  domains?: ActivatedResourceReference[];
+
+  /**
+   * Routes associated with the authorization policy.
+   */
+  routes?: ResourceReference[];
+}
+
+/**
+ * Authorization configuration parameters.
+ */
+@added(Versions.v2026_08_01_preview)
+@discriminator("identityProvider")
+model AuthPolicyConfig {
+  /**
+   * Identity provider used by the authorization configuration.
+   */
+  identityProvider: AuthPolicyConfigIdentityProvider;
+}
+
+/**
+ * Identity provider used by an authorization configuration.
+ */
+@added(Versions.v2026_08_01_preview)
+union AuthPolicyConfigIdentityProvider {
+  string,
+
+  /**
+   * Microsoft Entra ID.
+   */
+  EntraID: "EntraID",
+}
+
+/**
+ * Microsoft Entra ID authorization policy configuration.
+ */
+#suppress "@azure-tools/typespec-azure-core/casing-style" "Preserve the established API and SDK spelling of Entra ID."
+@added(Versions.v2026_08_01_preview)
+model AuthPolicyEntraIDConfig extends AuthPolicyConfig {
+  /**
+   * Identity provider used by the authorization configuration.
+   */
+  identityProvider: "EntraID";
+
+  /**
+   * Issuer or authority for the identity provider to validate.
+   */
+  issuer: string;
+
+  /**
+   * Audiences to validate.
+   */
+  @minItems(1)
+  audiences: string[];
+
+  /**
+   * Location of the authorization value in the HTTP request.
+   */
+  authLocation?: AuthLocation = AuthLocation.Header;
+
+  /**
+   * Selector within the authorization location used to find the identity.
+   */
+  authLocationSelector?: string;
+}
+
+/**
+ * Location of the authorization value in an HTTP request.
+ */
+@added(Versions.v2026_08_01_preview)
+union AuthLocation {
+  string,
+
+  /**
+   * The authorization value is in an HTTP request header.
+   */
+  Header: "Header",
+
+  /**
+   * The authorization value is in the request query string.
+   */
+  Query: "Query",
+
+  /**
+   * The authorization value is in an HTTP cookie.
+   */
+  Cookie: "Cookie",
+}
+
+/**
+ * Action applied when authorization fails.
+ */
+@added(Versions.v2026_08_01_preview)
+union AuthPolicyAction {
+  string,
+
+  /**
+   * Block the request.
+   */
+  Block: "Block",
+
+  /**
+   * Log the authorization failure and allow the request to continue.
+   */
+  Log: "Log",
+}
+
+/**
  * Caching settings for a caching-type route. To disable caching, do not provide a cacheConfiguration object.
  */
 model AfdRouteCacheConfiguration {

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Create.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Create.json
@@ -36,6 +36,42 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Block",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      }
+    },
     "201": {
       "body": {
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Create.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Create.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "resource": {
+      "properties": {
+        "action": "Block",
+        "associations": {
+          "domains": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+            }
+          ],
+          "isProfileLevel": false,
+          "routes": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+            }
+          ]
+        },
+        "authConfigs": [
+          {
+            "audiences": [
+              "11111111-1111-1111-1111-111111111111"
+            ],
+            "authLocation": "Header",
+            "authLocationSelector": "Authorization",
+            "identityProvider": "EntraID",
+            "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Block",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Creating"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Retry-After": 30
+      }
+    }
+  },
+  "operationId": "AuthPolicies_Create",
+  "title": "AuthPolicies_Create"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Delete.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Delete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Retry-After": 30
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AuthPolicies_Delete",
+  "title": "AuthPolicies_Delete"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Get.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Get.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Block",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      }
+    }
+  },
+  "operationId": "AuthPolicies_Get",
+  "title": "AuthPolicies_Get"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_ListByProfile.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_ListByProfile.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "profileName": "profile1",
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+            "name": "authPolicy1",
+            "properties": {
+              "action": "Block",
+              "associations": {
+                "domains": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+                  }
+                ],
+                "isProfileLevel": false,
+                "routes": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+                  }
+                ]
+              },
+              "authConfigs": [
+                {
+                  "audiences": [
+                    "11111111-1111-1111-1111-111111111111"
+                  ],
+                  "authLocation": "Header",
+                  "authLocationSelector": "Authorization",
+                  "identityProvider": "EntraID",
+                  "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+                }
+              ],
+              "deploymentStatus": "NotStarted",
+              "provisioningState": "Succeeded"
+            },
+            "type": "Microsoft.Cdn/profiles/authPolicies"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AuthPolicies_ListByProfile",
+  "title": "AuthPolicies_ListByProfile"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Update.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/examples/AuthPolicies_Update.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "authPolicyName": "authPolicy1",
+    "profileName": "profile1",
+    "properties": {
+      "properties": {
+        "action": "Log"
+      }
+    },
+    "resourceGroupName": "RG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/authPolicies/authPolicy1",
+        "name": "authPolicy1",
+        "properties": {
+          "action": "Log",
+          "associations": {
+            "domains": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/customDomains/domain1"
+              }
+            ],
+            "isProfileLevel": false,
+            "routes": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1"
+              }
+            ]
+          },
+          "authConfigs": [
+            {
+              "audiences": [
+                "11111111-1111-1111-1111-111111111111"
+              ],
+              "authLocation": "Header",
+              "authLocationSelector": "Authorization",
+              "identityProvider": "EntraID",
+              "issuer": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            }
+          ],
+          "deploymentStatus": "NotStarted",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Cdn/profiles/authPolicies"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG/providers/Microsoft.Cdn/operationResults/operationId?api-version=2026-08-01-preview",
+        "Retry-After": 30
+      }
+    }
+  },
+  "operationId": "AuthPolicies_Update",
+  "title": "AuthPolicies_Update"
+}

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/openapi.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/preview/2026-08-01-preview/openapi.json
@@ -70,6 +70,9 @@
       "name": "SecurityPolicies"
     },
     {
+      "name": "AuthPolicies"
+    },
+    {
       "name": "Secrets"
     },
     {
@@ -2139,6 +2142,372 @@
             "$ref": "./examples/AFDEndpoints_ValidateCustomDomain.json"
           }
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/authPolicies": {
+      "get": {
+        "operationId": "AuthPolicies_ListByProfile",
+        "tags": [
+          "AuthPolicies"
+        ],
+        "description": "Lists authorization policies associated with the profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "Name of the Azure Front Door Standard or Azure Front Door Premium or CDN profile which is unique within the resource group.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthPolicies_ListByProfile": {
+            "$ref": "./examples/AuthPolicies_ListByProfile.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/authPolicies/{authPolicyName}": {
+      "get": {
+        "operationId": "AuthPolicies_Get",
+        "tags": [
+          "AuthPolicies"
+        ],
+        "description": "Gets an existing authorization policy within a profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "Name of the Azure Front Door Standard or Azure Front Door Premium or CDN profile which is unique within the resource group.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          },
+          {
+            "name": "authPolicyName",
+            "in": "path",
+            "description": "Name of the authorization policy under the profile.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthPolicies_Get": {
+            "$ref": "./examples/AuthPolicies_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AuthPolicies_Create",
+        "tags": [
+          "AuthPolicies"
+        ],
+        "description": "Creates or updates an authorization policy within the specified profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "Name of the Azure Front Door Standard or Azure Front Door Premium or CDN profile which is unique within the resource group.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          },
+          {
+            "name": "authPolicyName",
+            "in": "path",
+            "description": "Name of the authorization policy under the profile.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The authorization policy properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'AuthPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthPolicies_Create": {
+            "$ref": "./examples/AuthPolicies_Create.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AuthPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "AuthPolicies_Update",
+        "tags": [
+          "AuthPolicies"
+        ],
+        "description": "Updates an existing authorization policy within a profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "Name of the Azure Front Door Standard or Azure Front Door Premium or CDN profile which is unique within the resource group.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          },
+          {
+            "name": "authPolicyName",
+            "in": "path",
+            "description": "Name of the authorization policy under the profile.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "Authorization policy update properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthPolicyUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthPolicy"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthPolicies_Update": {
+            "$ref": "./examples/AuthPolicies_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AuthPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AuthPolicies_Delete",
+        "tags": [
+          "AuthPolicies"
+        ],
+        "description": "Deletes an existing authorization policy within a profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "Name of the Azure Front Door Standard or Azure Front Door Premium or CDN profile which is unique within the resource group.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          },
+          {
+            "name": "authPolicyName",
+            "in": "path",
+            "description": "Name of the authorization policy under the profile.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 260,
+            "pattern": "^[a-zA-Z0-9]+(-*[a-zA-Z0-9])*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthPolicies_Delete": {
+            "$ref": "./examples/AuthPolicies_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/cdnCanMigrateToAfd": {
@@ -9408,6 +9777,273 @@
             "value": "SHA256"
           }
         ]
+      }
+    },
+    "AuthPolicy": {
+      "type": "object",
+      "description": "An authorization policy that maps authorization configurations to profile, domain, or route associations.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthPolicyProperties",
+          "description": "Properties required to create an authorization policy."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AuthPolicyAction": {
+      "type": "string",
+      "description": "Action applied when authorization fails.",
+      "enum": [
+        "Block",
+        "Log"
+      ],
+      "x-ms-enum": {
+        "name": "AuthPolicyAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Block",
+            "value": "Block",
+            "description": "Block the request."
+          },
+          {
+            "name": "Log",
+            "value": "Log",
+            "description": "Log the authorization failure and allow the request to continue."
+          }
+        ]
+      }
+    },
+    "AuthPolicyAssociation": {
+      "type": "object",
+      "description": "Resource associations for an authorization policy.",
+      "properties": {
+        "isProfileLevel": {
+          "type": "boolean",
+          "description": "Indicates whether the policy is associated at the profile level.",
+          "default": false
+        },
+        "domains": {
+          "type": "array",
+          "description": "Domains associated with the authorization policy.",
+          "items": {
+            "$ref": "#/definitions/ActivatedResourceReference"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "description": "Routes associated with the authorization policy.",
+          "items": {
+            "$ref": "#/definitions/ResourceReference"
+          }
+        }
+      }
+    },
+    "AuthPolicyConfig": {
+      "type": "object",
+      "description": "Authorization configuration parameters.",
+      "properties": {
+        "identityProvider": {
+          "$ref": "#/definitions/AuthPolicyConfigIdentityProvider",
+          "description": "Identity provider used by the authorization configuration."
+        }
+      },
+      "discriminator": "identityProvider",
+      "required": [
+        "identityProvider"
+      ]
+    },
+    "AuthPolicyConfigIdentityProvider": {
+      "type": "string",
+      "description": "Identity provider used by an authorization configuration.",
+      "enum": [
+        "EntraID"
+      ],
+      "x-ms-enum": {
+        "name": "AuthPolicyConfigIdentityProvider",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EntraID",
+            "value": "EntraID",
+            "description": "Microsoft Entra ID."
+          }
+        ]
+      }
+    },
+    "AuthPolicyEntraIDConfig": {
+      "type": "object",
+      "description": "Microsoft Entra ID authorization policy configuration.",
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "description": "Issuer or authority for the identity provider to validate."
+        },
+        "audiences": {
+          "type": "array",
+          "description": "Audiences to validate.",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "authLocation": {
+          "type": "string",
+          "description": "Location of the authorization value in the HTTP request.",
+          "default": "Header",
+          "enum": [
+            "Header",
+            "Query",
+            "Cookie"
+          ],
+          "x-ms-enum": {
+            "name": "AuthLocation",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Header",
+                "value": "Header",
+                "description": "The authorization value is in an HTTP request header."
+              },
+              {
+                "name": "Query",
+                "value": "Query",
+                "description": "The authorization value is in the request query string."
+              },
+              {
+                "name": "Cookie",
+                "value": "Cookie",
+                "description": "The authorization value is in an HTTP cookie."
+              }
+            ]
+          }
+        },
+        "authLocationSelector": {
+          "type": "string",
+          "description": "Selector within the authorization location used to find the identity."
+        }
+      },
+      "required": [
+        "issuer",
+        "audiences"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/AuthPolicyConfig"
+        }
+      ],
+      "x-ms-discriminator-value": "EntraID"
+    },
+    "AuthPolicyListResult": {
+      "type": "object",
+      "description": "The response of a AuthPolicy list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AuthPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/AuthPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AuthPolicyProperties": {
+      "type": "object",
+      "description": "Properties of the authorization policy.",
+      "properties": {
+        "authConfigs": {
+          "type": "array",
+          "description": "Authorization configurations for the policy.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/AuthPolicyConfig"
+          },
+          "x-ms-identifiers": []
+        },
+        "associations": {
+          "$ref": "#/definitions/AuthPolicyAssociation",
+          "description": "Resource associations for the authorization policy."
+        },
+        "action": {
+          "type": "string",
+          "description": "Action to apply when authorization fails.",
+          "default": "Block",
+          "enum": [
+            "Block",
+            "Log"
+          ],
+          "x-ms-enum": {
+            "name": "AuthPolicyAction",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Block",
+                "value": "Block",
+                "description": "Block the request."
+              },
+              {
+                "name": "Log",
+                "value": "Log",
+                "description": "Log the authorization failure and allow the request to continue."
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "authConfigs",
+        "associations"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/AFDStateProperties"
+        }
+      ]
+    },
+    "AuthPolicyUpdateParameters": {
+      "type": "object",
+      "description": "Parameters for updating an authorization policy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthPolicyUpdatePropertiesParameters",
+          "description": "Properties to update on the authorization policy.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "AuthPolicyUpdatePropertiesParameters": {
+      "type": "object",
+      "description": "Writable properties of an authorization policy.",
+      "properties": {
+        "authConfigs": {
+          "type": "array",
+          "description": "Authorization configurations for the policy.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/AuthPolicyConfig"
+          },
+          "x-ms-identifiers": []
+        },
+        "associations": {
+          "$ref": "#/definitions/AuthPolicyAssociation",
+          "description": "Resource associations for the authorization policy."
+        },
+        "action": {
+          "$ref": "#/definitions/AuthPolicyAction",
+          "description": "Action to apply when authorization fails."
+        }
       }
     },
     "AutoGeneratedDomainNameLabelScope": {


### PR DESCRIPTION
## Summary
- add the profile-level AuthPolicy ARM resource and CRUD/list operations
- define Entra ID authorization configuration and association models
- add request/response examples for AuthPolicy operations
- generate the 2026-08-01-preview OpenAPI output

## Validation
- TypeSpec compilation succeeds with warnings treated as errors